### PR TITLE
fix(oldapiiblockdataprovider): bitrix core bug with filter by ACTIVE_FROM in old api getlist

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -17,8 +17,8 @@ class bx_data_provider extends CModule
 
     public function __construct()
     {
-        $this->MODULE_VERSION = "1.19.0";
-        $this->MODULE_VERSION_DATE = "2024-04-01 15:20:00";
+        $this->MODULE_VERSION = "1.18.2";
+        $this->MODULE_VERSION_DATE = "2024-04-03 18:00:00";
         $this->MODULE_NAME = "Провайдер данных";
         $this->MODULE_DESCRIPTION = "Провайдер данных";
     }

--- a/lib/oldapiiblockdataprovider.php
+++ b/lib/oldapiiblockdataprovider.php
@@ -366,6 +366,24 @@ class OldApiIblockDataProvider extends BaseDataProvider implements IblockDataPro
             $filter['MIN_PERMISSION'] = $filter['=MIN_PERMISSION'];
             unset($filter['=MIN_PERMISSION']);
         }
+        $operationTypes = ['=', '<', '<=', '>', '>=', '==', ''];
+        foreach ($operationTypes as $operationType) {
+            if (array_key_exists("{$operationType}ACTIVE_FROM", $filter)) {
+                $filter["{$operationType}DATE_ACTIVE_FROM"] = $filter["{$operationType}ACTIVE_FROM"];
+                unset($filter["{$operationType}ACTIVE_FROM"]);
+            }
+        }
+        foreach ($operationTypes as $operationType) {
+            if (array_key_exists("{$operationType}ACTIVE_TO", $filter)) {
+                $filter["{$operationType}DATE_ACTIVE_TO"] = $filter["{$operationType}ACTIVE_TO"];
+                unset($filter["{$operationType}ACTIVE_TO"]);
+            }
+        }
+        foreach ($filter as $key => &$filterValue) {
+            if (is_int($key) && is_array($filterValue)) {
+                $this->updateFilterForOldApi($filterValue);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
В ядре битрикса в старом гетлисте обнаружил баг. В документации указано, что поля ACTIVE_FROM и ACTIVE_TO устаревшие. <ACTIVE_FROM конвертируется в >= при подставлении в mysql запрос. а !ACTIVE_FROM - в <. DATE_ACTIVE_FROM обрабатывается корректно, так как должно (если меньше, то меньше и т.д.).
Место бага: /bitrix/modules/iblock/classes/general/iblockelement.php:1014
Реализовал подмену полей фильтра.