### PR TITLE
fix(oldapiiblockdataprovider): fixed unprepared params in count method

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -17,8 +17,8 @@ class bx_data_provider extends CModule
 
     public function __construct()
     {
-        $this->MODULE_VERSION = "1.18.2";
-        $this->MODULE_VERSION_DATE = "2024-04-03 18:00:00";
+        $this->MODULE_VERSION = "1.18.3";
+        $this->MODULE_VERSION_DATE = "2024-04-18 22:00:00";
         $this->MODULE_NAME = "Провайдер данных";
         $this->MODULE_DESCRIPTION = "Провайдер данных";
     }

--- a/lib/oldapiiblockdataprovider.php
+++ b/lib/oldapiiblockdataprovider.php
@@ -545,6 +545,10 @@ class OldApiIblockDataProvider extends BaseDataProvider implements IblockDataPro
     {
         $pkName = $this->getPkName();
         $params = empty($query) ? [] : BxQueryAdapter::init($query)->toArray();
+        $params = $this->prepareParams($params);
+        if (!empty($params['filter'])) {
+            $this->updateFilterForOldApi($params['filter']);
+        }
         $defaultFilter = $this->defaultFilter;
         if (!empty($defaultFilter)) {
             $params['filter'] = array_merge($params['filter'] ?? [], $defaultFilter);


### PR DESCRIPTION
Из-за неподготовленных параметров метод getDataCount работал некорректно и возвращал 0 в случаях, когда элементов было больше.